### PR TITLE
feat: add avatar upload and removal for user profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,8 @@ lerna-debug.log*
 *.db
 *.db-journal
 
+# Uploads
+uploads/
+
 # OS
 Thumbs.db

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,6 +22,7 @@
     "express": "^4.18.2",
     "express-rate-limit": "^8.2.1",
     "jsonwebtoken": "^9.0.2",
+    "multer": "^2.0.2",
     "socket.io": "^4.6.1",
     "zod": "^3.22.4"
   },
@@ -31,6 +32,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.5",
+    "@types/multer": "^2.0.0",
     "@types/node": "^20.11.5",
     "@types/supertest": "^6.0.3",
     "supertest": "^7.1.4",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,4 +1,6 @@
 import express from 'express'
+import path from 'path'
+import { fileURLToPath } from 'url'
 import cors from 'cors'
 import cookieParser from 'cookie-parser'
 import { apiRateLimit } from './middleware/rateLimit'
@@ -7,6 +9,8 @@ import boardsRoutes from './routes/boards'
 import boardMembersRoutes from './routes/boardMembers'
 import listsRoutes from './routes/lists'
 import cardsRoutes from './routes/cards'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export function createApp() {
   const app = express()
@@ -26,6 +30,7 @@ export function createApp() {
   app.use(express.json())
   app.use(express.urlencoded({ extended: true }))
   app.use('/api', apiRateLimit)
+  app.use('/uploads', express.static(path.join(__dirname, '..', 'uploads')))
 
   app.get('/health', (_req, res) => {
     res.json({ status: 'ok', timestamp: new Date().toISOString() })

--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -1,13 +1,20 @@
 import type { Request, Response } from 'express'
 import { Prisma } from '@prisma/client'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
 import type { RegisterInput, LoginInput } from '@hello/validation'
 import type { ApiResponse, User } from '@hello/types'
 import {
   createUser,
   generateTokens,
   findUserByEmail,
+  findUserById,
   verifyPassword,
+  updateUserAvatar,
 } from '../services/auth.service'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const COOKIE_BASE = {
   httpOnly: true,
@@ -115,4 +122,72 @@ export function getCurrentUser(req: Request, res: Response) {
     success: true,
     data: req.user,
   } satisfies ApiResponse<Omit<User, 'passwordHash'>>)
+}
+
+function deleteAvatarFile(avatarUrl: string) {
+  try {
+    const filePath = path.join(__dirname, '..', '..', avatarUrl)
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath)
+    }
+  } catch {
+    // Non-critical — log but don't fail the request
+    console.error('Failed to delete old avatar file:', avatarUrl)
+  }
+}
+
+export async function uploadAvatar(req: Request, res: Response) {
+  try {
+    if (!req.file) {
+      return res.status(400).json({
+        success: false,
+        error: 'No file uploaded',
+      } satisfies ApiResponse)
+    }
+
+    const userId = req.user!.id
+    const currentUser = await findUserById(userId)
+
+    if (currentUser?.avatarUrl) {
+      deleteAvatarFile(currentUser.avatarUrl)
+    }
+
+    const avatarUrl = `/uploads/avatars/${req.file.filename}`
+    const user = await updateUserAvatar(userId, avatarUrl)
+
+    return res.status(200).json({
+      success: true,
+      data: { user },
+    } satisfies ApiResponse<{ user: Omit<User, 'passwordHash'> }>)
+  } catch (error) {
+    console.error('Avatar upload error:', error)
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to upload avatar',
+    } satisfies ApiResponse)
+  }
+}
+
+export async function removeAvatar(req: Request, res: Response) {
+  try {
+    const userId = req.user!.id
+    const currentUser = await findUserById(userId)
+
+    if (currentUser?.avatarUrl) {
+      deleteAvatarFile(currentUser.avatarUrl)
+    }
+
+    const user = await updateUserAvatar(userId, null)
+
+    return res.status(200).json({
+      success: true,
+      data: { user },
+    } satisfies ApiResponse<{ user: Omit<User, 'passwordHash'> }>)
+  } catch (error) {
+    console.error('Avatar removal error:', error)
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to remove avatar',
+    } satisfies ApiResponse)
+  }
 }

--- a/apps/api/src/controllers/avatar.controller.test.ts
+++ b/apps/api/src/controllers/avatar.controller.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Request, NextFunction } from 'express'
+import request from 'supertest'
+import { createApp } from '../app'
+import * as authService from '../services/auth.service'
+import { avatarUpload } from '../middleware/upload'
+
+vi.mock('../services/auth.service')
+vi.mock('@hello/database', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}))
+vi.mock('../middleware/upload', () => ({
+  avatarUpload: vi.fn((_req: unknown, _res: unknown, next: () => void) => next()),
+}))
+
+const mockUser = {
+  id: 'user-123',
+  email: 'test@example.com',
+  name: 'Test User',
+  avatarUrl: null as string | null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+function authenticateAs(user = mockUser) {
+  vi.mocked(authService.verifyToken).mockReturnValue({ valid: true, userId: user.id })
+  vi.mocked(authService.findUserById).mockResolvedValue(user)
+}
+
+function mockMulterFile(filename: string) {
+  vi.mocked(avatarUpload).mockImplementation((req: unknown, _res: unknown, next: unknown) => {
+    ;(req as Request).file = {
+      filename,
+      originalname: 'photo.png',
+      mimetype: 'image/png',
+      size: 1024,
+      fieldname: 'avatar',
+      encoding: '7bit',
+      destination: '',
+      path: '',
+      buffer: Buffer.alloc(0),
+      stream: null as never,
+    }
+    ;(next as NextFunction)()
+  })
+}
+
+describe('POST /api/auth/avatar', () => {
+  const app = createApp()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.JWT_SECRET = 'test-secret'
+    // Default: multer mock passes through without setting req.file
+    vi.mocked(avatarUpload).mockImplementation((_req: unknown, _res: unknown, next: unknown) =>
+      (next as NextFunction)()
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    const response = await request(app).post('/api/auth/avatar')
+
+    expect(response.status).toBe(401)
+    expect(response.body).toEqual({
+      success: false,
+      error: 'Not authenticated',
+    })
+  })
+
+  it('should return 400 when no file is uploaded', async () => {
+    authenticateAs()
+
+    const response = await request(app)
+      .post('/api/auth/avatar')
+      .set('Cookie', 'accessToken=valid.jwt.token')
+
+    expect(response.status).toBe(400)
+    expect(response.body).toEqual({
+      success: false,
+      error: 'No file uploaded',
+    })
+  })
+
+  it('should upload avatar and return updated user', async () => {
+    authenticateAs()
+    mockMulterFile('user-123-12345.png')
+
+    const updatedUser = { ...mockUser, avatarUrl: '/uploads/avatars/user-123-12345.png' }
+    vi.mocked(authService.updateUserAvatar).mockResolvedValue(updatedUser)
+
+    const response = await request(app)
+      .post('/api/auth/avatar')
+      .set('Cookie', 'accessToken=valid.jwt.token')
+
+    expect(response.status).toBe(200)
+    expect(response.body.success).toBe(true)
+    expect(response.body.data.user).toEqual(
+      expect.objectContaining({
+        id: 'user-123',
+        avatarUrl: '/uploads/avatars/user-123-12345.png',
+      })
+    )
+    expect(authService.updateUserAvatar).toHaveBeenCalledWith(
+      'user-123',
+      '/uploads/avatars/user-123-12345.png'
+    )
+  })
+
+  it('should replace existing avatar when user already has one', async () => {
+    const userWithAvatar = { ...mockUser, avatarUrl: '/uploads/avatars/old-avatar.png' }
+    authenticateAs(userWithAvatar)
+    mockMulterFile('user-123-99999.png')
+
+    const updatedUser = { ...mockUser, avatarUrl: '/uploads/avatars/user-123-99999.png' }
+    vi.mocked(authService.updateUserAvatar).mockResolvedValue(updatedUser)
+
+    const response = await request(app)
+      .post('/api/auth/avatar')
+      .set('Cookie', 'accessToken=valid.jwt.token')
+
+    expect(response.status).toBe(200)
+    expect(response.body.success).toBe(true)
+    expect(authService.updateUserAvatar).toHaveBeenCalledWith(
+      'user-123',
+      '/uploads/avatars/user-123-99999.png'
+    )
+  })
+
+  it('should return 500 when service throws', async () => {
+    authenticateAs()
+    mockMulterFile('user-123-12345.png')
+    vi.mocked(authService.updateUserAvatar).mockRejectedValue(new Error('DB error'))
+
+    const response = await request(app)
+      .post('/api/auth/avatar')
+      .set('Cookie', 'accessToken=valid.jwt.token')
+
+    expect(response.status).toBe(500)
+    expect(response.body).toEqual({
+      success: false,
+      error: 'Failed to upload avatar',
+    })
+  })
+})
+
+describe('DELETE /api/auth/avatar', () => {
+  const app = createApp()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.JWT_SECRET = 'test-secret'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    const response = await request(app).delete('/api/auth/avatar')
+
+    expect(response.status).toBe(401)
+    expect(response.body).toEqual({
+      success: false,
+      error: 'Not authenticated',
+    })
+  })
+
+  it('should remove avatar and return updated user', async () => {
+    const userWithAvatar = { ...mockUser, avatarUrl: '/uploads/avatars/user-123-12345.png' }
+    authenticateAs(userWithAvatar)
+
+    const updatedUser = { ...mockUser, avatarUrl: null }
+    vi.mocked(authService.updateUserAvatar).mockResolvedValue(updatedUser)
+
+    const response = await request(app)
+      .delete('/api/auth/avatar')
+      .set('Cookie', 'accessToken=valid.jwt.token')
+
+    expect(response.status).toBe(200)
+    expect(response.body.success).toBe(true)
+    expect(response.body.data.user).toEqual(
+      expect.objectContaining({
+        id: 'user-123',
+        avatarUrl: null,
+      })
+    )
+    expect(authService.updateUserAvatar).toHaveBeenCalledWith('user-123', null)
+  })
+
+  it('should succeed when user has no existing avatar', async () => {
+    authenticateAs()
+
+    const updatedUser = { ...mockUser, avatarUrl: null }
+    vi.mocked(authService.updateUserAvatar).mockResolvedValue(updatedUser)
+
+    const response = await request(app)
+      .delete('/api/auth/avatar')
+      .set('Cookie', 'accessToken=valid.jwt.token')
+
+    expect(response.status).toBe(200)
+    expect(response.body.success).toBe(true)
+    expect(authService.updateUserAvatar).toHaveBeenCalledWith('user-123', null)
+  })
+
+  it('should return 500 when service throws', async () => {
+    authenticateAs()
+    vi.mocked(authService.updateUserAvatar).mockRejectedValue(new Error('DB error'))
+
+    const response = await request(app)
+      .delete('/api/auth/avatar')
+      .set('Cookie', 'accessToken=valid.jwt.token')
+
+    expect(response.status).toBe(500)
+    expect(response.body).toEqual({
+      success: false,
+      error: 'Failed to remove avatar',
+    })
+  })
+})

--- a/apps/api/src/middleware/upload.ts
+++ b/apps/api/src/middleware/upload.ts
@@ -1,0 +1,37 @@
+import multer from 'multer'
+import path from 'path'
+import fs from 'fs'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const uploadsDir = path.join(__dirname, '..', '..', 'uploads', 'avatars')
+
+if (!fs.existsSync(uploadsDir)) {
+  fs.mkdirSync(uploadsDir, { recursive: true })
+}
+
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif']
+const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5 MB
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => {
+    cb(null, uploadsDir)
+  },
+  filename: (req, file, cb) => {
+    const ext = path.extname(file.originalname).toLowerCase()
+    const userId = req.user?.id ?? 'unknown'
+    cb(null, `${userId}-${Date.now()}${ext}`)
+  },
+})
+
+export const avatarUpload = multer({
+  storage,
+  limits: { fileSize: MAX_FILE_SIZE },
+  fileFilter: (_req, file, cb) => {
+    if (ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+      cb(null, true)
+    } else {
+      cb(new Error('Only JPEG, PNG, WebP, and GIF images are allowed'))
+    }
+  },
+}).single('avatar')

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,9 +1,17 @@
 import { Router } from 'express'
 import { registerSchema, loginSchema } from '@hello/validation'
-import { register, login, logout, getCurrentUser } from '../controllers/auth.controller'
+import {
+  register,
+  login,
+  logout,
+  getCurrentUser,
+  uploadAvatar,
+  removeAvatar,
+} from '../controllers/auth.controller'
 import { authMiddleware } from '../middleware/auth'
 import { validateBody } from '../middleware/validate'
 import { authRateLimit } from '../middleware/rateLimit'
+import { avatarUpload } from '../middleware/upload'
 
 const router = Router()
 
@@ -11,5 +19,7 @@ router.post('/register', authRateLimit, validateBody(registerSchema), register)
 router.post('/login', authRateLimit, validateBody(loginSchema), login)
 router.post('/logout', logout)
 router.get('/me', authMiddleware, getCurrentUser)
+router.post('/avatar', authMiddleware, avatarUpload, uploadAvatar)
+router.delete('/avatar', authMiddleware, removeAvatar)
 
 export default router

--- a/apps/api/src/services/auth.service.ts
+++ b/apps/api/src/services/auth.service.ts
@@ -66,6 +66,24 @@ export async function findUserById(id: string): Promise<Omit<User, 'passwordHash
   })
 }
 
+export async function updateUserAvatar(
+  userId: string,
+  avatarUrl: string | null
+): Promise<Omit<User, 'passwordHash'>> {
+  return prisma.user.update({
+    where: { id: userId },
+    data: { avatarUrl },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      avatarUrl: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  })
+}
+
 export type TokenVerifyResult = { valid: true; userId: string } | { valid: false; expired: boolean }
 
 export function verifyToken(token: string): TokenVerifyResult {

--- a/apps/web/src/components/common/Sidebar.tsx
+++ b/apps/web/src/components/common/Sidebar.tsx
@@ -1,9 +1,10 @@
 import { Link, useLocation } from 'react-router-dom'
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import { useAuth } from '@/hooks/useAuth'
 import { useAuthStore, useThemeStore } from '@/stores'
-import { getInitials } from '@/utils'
 import Logo from '../features/auth/Logo'
+import { Avatar } from './Avatar'
+import { API_BASE_URL } from '@/lib/api'
 import { HomeIcon, NotificationsIcon, SettingsIcon, MoonIcon, SunIcon, LogoutIcon } from '../icons'
 
 interface NavLink {
@@ -38,8 +39,9 @@ const inactiveStyles =
 const activeStyles = 'bg-theme-accent dark:bg-theme-dark-accent text-white'
 
 const Sidebar = ({ isOpen, onClose }: SidebarProps) => {
-  const { logout } = useAuth()
+  const { logout, uploadAvatar, isUploadingAvatar } = useAuth()
   const { user } = useAuthStore()
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const { resolvedTheme, toggleTheme } = useThemeStore()
   const location = useLocation()
 
@@ -110,12 +112,33 @@ const Sidebar = ({ isOpen, onClose }: SidebarProps) => {
         {resolvedTheme === 'dark' ? <MoonIcon /> : <SunIcon />}
       </button>
 
-      <div
-        className="w-11 h-11 bg-theme-gradient rounded-full flex items-center justify-center text-sm font-semibold text-white cursor-pointer"
+      <button
+        type="button"
+        aria-label="Change avatar"
         title={user?.name ?? 'User'}
+        onClick={() => fileInputRef.current?.click()}
+        className={`border-none bg-transparent p-0 cursor-pointer rounded-full ${isUploadingAvatar ? 'opacity-50' : ''}`}
+        disabled={isUploadingAvatar}
       >
-        {user?.name ? getInitials(user.name) : '??'}
-      </div>
+        <Avatar
+          name={user?.name ?? 'User'}
+          avatarUrl={user?.avatarUrl ? `${API_BASE_URL}${user.avatarUrl}` : null}
+          size="md"
+        />
+      </button>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp,image/gif"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0]
+          if (file) {
+            uploadAvatar(file)
+            e.target.value = ''
+          }
+        }}
+      />
 
       <button
         aria-label="Logout"

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import type { AuthResponse, User, RegisterCredentials, LoginCredentials } from '@hello/types'
-import { fetcher, ApiError } from '../lib/api'
+import { fetcher, uploadFile, ApiError } from '../lib/api'
 import { useAuthStore } from '../stores'
 
 const AUTH_KEYS = {
@@ -84,6 +84,22 @@ export function useAuth() {
     },
   })
 
+  const uploadAvatarMutation = useMutation({
+    mutationFn: (file: File) => uploadFile<{ user: User }>('/api/auth/avatar', file, 'avatar'),
+    onSuccess: (data) => {
+      setUser(data.user)
+      queryClient.setQueryData(AUTH_KEYS.user, data.user)
+    },
+  })
+
+  const removeAvatarMutation = useMutation({
+    mutationFn: () => fetcher<{ user: User }>('/api/auth/avatar', { method: 'DELETE' }),
+    onSuccess: (data) => {
+      setUser(data.user)
+      queryClient.setQueryData(AUTH_KEYS.user, data.user)
+    },
+  })
+
   return {
     user,
     isAuthenticated,
@@ -101,5 +117,9 @@ export function useAuth() {
 
     logout: logoutMutation.mutate,
     isLoggingOut: logoutMutation.isPending,
+
+    uploadAvatar: uploadAvatarMutation.mutate,
+    isUploadingAvatar: uploadAvatarMutation.isPending,
+    removeAvatar: removeAvatarMutation.mutate,
   }
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -34,3 +34,22 @@ export async function fetcher<T>(endpoint: string, options: RequestInit = {}): P
 
   return data.data as T
 }
+
+export async function uploadFile<T>(endpoint: string, file: File, fieldName: string): Promise<T> {
+  const formData = new FormData()
+  formData.append(fieldName, file)
+
+  const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    method: 'POST',
+    credentials: 'include',
+    body: formData,
+  })
+
+  const data: ApiResponse<T> = await response.json()
+
+  if (!response.ok || !data.success) {
+    throw new ApiError(data.error || 'Upload failed', response.status, data.details)
+  }
+
+  return data.data as T
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.3
+      multer:
+        specifier: ^2.0.2
+        version: 2.0.2
       socket.io:
         specifier: ^4.6.1
         version: 4.8.3
@@ -90,6 +93,9 @@ importers:
       '@types/jsonwebtoken':
         specifier: ^9.0.5
         version: 9.0.10
+      '@types/multer':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@types/node':
         specifier: ^20.11.5
         version: 20.19.27
@@ -1222,6 +1228,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/multer@2.0.0':
+    resolution: {integrity: sha512-C3Z9v9Evij2yST3RSBktxP9STm6OdMc5uR1xF1SGr98uv8dUlAL2hqwrZ3GVB3uyMyiegnscEK6PGtYvNrjTjw==}
+
   '@types/node@20.19.27':
     resolution: {integrity: sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==}
 
@@ -1428,6 +1437,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  append-field@1.0.0:
+    resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
+
   aproba@2.1.0:
     resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
 
@@ -1523,6 +1535,13 @@ packages:
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1635,6 +1654,10 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
 
   concurrently@8.2.2:
     resolution: {integrity: sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==}
@@ -2596,6 +2619,10 @@ packages:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
 
+  mkdirp@0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
+
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
@@ -2616,6 +2643,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  multer@2.0.2:
+    resolution: {integrity: sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==}
+    engines: {node: '>= 10.16.0'}
 
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
@@ -3222,6 +3253,10 @@ packages:
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
+
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
@@ -3399,6 +3434,9 @@ packages:
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
+
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -4601,6 +4639,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/multer@2.0.0':
+    dependencies:
+      '@types/express': 4.17.25
+
   '@types/node@20.19.27':
     dependencies:
       undici-types: 6.21.0
@@ -4869,6 +4911,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  append-field@1.0.0: {}
+
   aproba@2.1.0: {}
 
   are-we-there-yet@2.0.0:
@@ -4968,6 +5012,12 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
   buffer-equal-constant-time@1.0.1: {}
+
+  buffer-from@1.1.2: {}
+
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
 
   bytes@3.1.2: {}
 
@@ -5085,6 +5135,13 @@ snapshots:
   component-emitter@1.3.1: {}
 
   concat-map@0.0.1: {}
+
+  concat-stream@2.0.0:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      typedarray: 0.0.6
 
   concurrently@8.2.2:
     dependencies:
@@ -6102,6 +6159,10 @@ snapshots:
       minipass: 3.3.6
       yallist: 4.0.0
 
+  mkdirp@0.5.6:
+    dependencies:
+      minimist: 1.2.8
+
   mkdirp@1.0.4: {}
 
   ms@2.0.0: {}
@@ -6132,6 +6193,16 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
+
+  multer@2.0.2:
+    dependencies:
+      append-field: 1.0.0
+      busboy: 1.6.0
+      concat-stream: 2.0.0
+      mkdirp: 0.5.6
+      object-assign: 4.1.1
+      type-is: 1.6.18
+      xtend: 4.0.2
 
   mute-stream@2.0.0: {}
 
@@ -6730,6 +6801,8 @@ snapshots:
 
   std-env@3.9.0: {}
 
+  streamsearch@1.1.0: {}
+
   strict-event-emitter@0.5.1: {}
 
   string-argv@0.3.2: {}
@@ -6931,6 +7004,8 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  typedarray@0.0.6: {}
 
   typescript@5.9.3: {}
 


### PR DESCRIPTION
## Summary
- Wire up the existing `avatarUrl` field with file upload support using multer (disk storage, JPEG/PNG/WebP/GIF, 5MB max)
- Add `POST /api/auth/avatar` and `DELETE /api/auth/avatar` endpoints with static file serving at `/uploads`
- Make the sidebar avatar clickable to open a file picker, uploading on select with immediate UI update

## Test plan
- [ ] `pnpm type-check` and `pnpm lint` pass
- [ ] Run `pnpm dev`, log in, click sidebar avatar, select an image — avatar updates immediately
- [ ] Refresh the page — avatar persists (DB URL + static file)
- [ ] Navigate to a board — avatar shows in active users
- [ ] Upload a new avatar to replace the old one — old file is deleted from disk
- [ ] 9 new tests pass (`pnpm --filter @hello/api test:run`)